### PR TITLE
Update rur.ttl

### DIFF
--- a/rur.ttl
+++ b/rur.ttl
@@ -80,7 +80,6 @@ rur:Batholith
   a skos:Concept ;
   dcterms:references "Wikipedia (accessed 07.09.2021): Batholith <https://en.wikipedia.org/wiki/Batholith>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "A large mass of intrusive igneous (plutonic) rock that is generally larger than 100 square kilometres in area and has cooled from magma deep in the Earth's crust (Wikipedia, accessed 07.09.2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrbth" ;
@@ -93,7 +92,6 @@ rur:Bed
   dcterms:references "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ;
   dcterms:references "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Member ;
   skos:definition "Bed/Beds: The smallest formal unit in the hierarchy of sedimentary lithostratigraphic units, e.g. a single stratum lithologically distinguishable from other layers above and below (Salvador, 2013; Murphy & Salvador, Online)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrbed" ;
@@ -105,7 +103,6 @@ rur:Beds
   a skos:Concept ;
   dcterms:references "Staines, H.R.E., 1985: Field Geologist's Guide to Lithostratigraphic Nomenclature in Australia. Australian Journal of Earth Sciences, 32(2), 83-106. <https://doi.org/10.1080/08120098508729316>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Member ;
   skos:definition "beds (uncapitalised): an informal, unranked unit applied to a sequence of poorly known strata until further work is carried out, as advised in the Field Geologist’s Guide to Lithostratigraphic Nomenclature in Australia (Staines, 1985), and endorsed by the Stratigraphic Nomenclature Committee, Geological Society of Australia."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrbds" ;
@@ -151,7 +148,6 @@ rur:Complex
   dcterms:references "Jell, P.A. (Editor), 2013: Geology of Queensland. Geological Survey of Queensland, Brisbane, 1063 pages. <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/reports-news/geology-queensland-book-map>"@en ;
   dcterms:references "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Supercomplex ;
   skos:definition "The rank of a rock unit that embraces a mixture of diverse types of any genetic (sedimentary, igneous, metamorphic) class of rocks or a mixture of two or more genetic classes, and characterised by irregularly-mixed lithology or by highly-complicated structural relations [rephrased from International Stratigraphic Guide/ISG (Salvador, 2013; Murphy & Salvador, Online)]. Two or more associated complex rock units may be grouped and ranked as a supercomplex, and a complex rock unit may be divided and ranked into two or more subcomplex rock units (Variously after: Subcommission on Quaternary Stratigraphy; Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrcom" ;
@@ -163,7 +159,6 @@ rur:ConeSheet
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "A sheet with a cone shape that dips inwards towards a central ‘focal’ point (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrics" ;
@@ -187,7 +182,6 @@ rur:Diatreme
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "A pipe filled with volcanic breccia that is inferred to form through gaseous disruption (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrdia" ;
@@ -200,7 +194,6 @@ rur:Dyke
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:altLabel "Dike"@en ;
-  skos:broader rur:Intrusion ;
   skos:definition "A sheet emplaced along a steep to vertical fracture, normally discordant to the host-rock structure (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrdyk" ;
@@ -226,7 +219,6 @@ rur:Flow
   dcterms:references "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021.<https://stratigraphy.org/guide/>"@en ;
   dcterms:references "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Member ;
   skos:definition "A discrete extrusive volcanic body distinguishable by texture, composition, or other objective criteria (Salvador, 2013; Murphy & Salvador, Online)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrflw" ;
@@ -238,7 +230,6 @@ rur:Formation
   dcterms:references "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ;
   dcterms:references "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Subgroup ;
   skos:definition "The primary formal unit of lithostratigraphic classification. Formations are the only formal lithostratigraphic units into which the stratigraphic column everywhere should be divided completely on the basis of lithology (Salvador, 2013; Murphy & Salvador, Online)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrfmn" ;
@@ -250,7 +241,6 @@ rur:Group
   dcterms:references "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ;
   dcterms:references "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Supergroup ;
   skos:definition "A succession of two or more contiguous or associated formations with significant and diagnostic lithologic properties in common (Salvador, 2013; Murphy & Salvador, Online)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrgrp" ;
@@ -262,7 +252,6 @@ rur:Intrusion
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:altLabel "Igneous Intrusion"@en ;
-  skos:broader rur:IntrusionCentreCluster ;
   skos:definition "A body of rock formed by the emplacement of magma which solidifies before reaching the Earth's surface (After: Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rriin" ;
@@ -274,7 +263,6 @@ rur:IntrusionCentre
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:IntrusionCentreCluster ;
   skos:definition "A group of two or more related intrusive units of lower rank (below suite and subsuite, respectively at Rank 2 and Rank 3 in BRUCS) focused tightly around a central point and usually intersecting to some degree (After: Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrice" ;
@@ -282,23 +270,10 @@ rur:IntrusionCentre
   skos:related geof:IgneousIntrusiveRockUnit ;
   skos:scopeNote "Igneous intrusions may be grouped in centres (or clusters), expressing genetic and spatial relationships, these groupings (centres/clusters) being classified here at Rank 4, following Gillespie & Leslie (2021). Per the example of the cited authors, a centre could comprise two intersecting plutons, and several ring-dykes, a dyke-swarm and a number of pipes that intersect the plutons or are spatially closely associated with them."@en ;
 .
-rur:IntrusionCentreCluster
-  a skos:Concept ;
-  dcterms:references "Modified from: Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-  rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Subsuite ;
-  skos:definition "A group of two or more related igneous intrusive rock units of lower rank (below suite and subsuite, respectively at Rank 2 and Rank 3 in BRUCS), either focused tightly around a central point and usually intersecting to some degree (‘intrusion centre’ or simply ‘centre’) or associated spatially but not focussed tightly (‘intrusion cluster’ or simply ‘cluster’) [After: Gillespie & Leslie, 2021]."@en ;
-  skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:notation "rricc" ;
-  skos:prefLabel "centre/cluster"@en ;
-  skos:related geof:IgneousIntrusiveRockUnit ;
-  skos:scopeNote "Igneous intrusions may be grouped in centres or clusters, expressing genetic and spatial relationships, these groupings being classified here at Rank 4 (albeit concatenated), after Gillespie & Leslie (2021)."@en ;
-.
 rur:IntrusionCluster
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:IntrusionCentreCluster ;
   skos:definition "A group of two or more related intrusive units of lower rank (below suite and subsuite, respectively at Rank 2 and Rank 3 in BRUCS) that are associated spatially but not focussed tightly (After: Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rricl" ;
@@ -322,7 +297,6 @@ rur:Laccolith
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "An intrusion that is roughly circular in plan, generally with a planar floor and domed roof (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrlac" ;
@@ -334,7 +308,6 @@ rur:Lopolith
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "An intrusion that is kilometre-scale or larger and broadly saucer-shaped (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrlop" ;
@@ -409,7 +382,6 @@ rur:Neck
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "A pipe inferred to have fed a volcano, now infilled with collapsed material from the vent (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrnek" ;
@@ -433,7 +405,6 @@ rur:Ophiolite
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Subassemblage ;
   skos:definition "A unit formed of obducted oceanic crust, generally recognized as having a mixed-class character comprising several layers of ultrabasic and basic igneous rock, dykes and other intrusions, pillow lavas and sea-floor sediments, with or without subjacent mantle (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rroph" ;
@@ -459,7 +430,6 @@ rur:Pipe
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "An intrusion sensu lato that is cylindrical and normally steeply orientated (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrpip" ;
@@ -483,7 +453,6 @@ rur:Plug
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "A pipe inferred to have fed a volcano, but generally lacking collapsed material from the vent (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrplg" ;
@@ -507,7 +476,6 @@ rur:Pluton
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "An intrusion sensu lato that is kilometre-scale or larger, and cylindrical, lenticular or tabular (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrplu" ;
@@ -519,7 +487,6 @@ rur:PlutonCluster
   a skos:Concept ;
   dcterms:references "Jell, P.A. (Editor), 2013: Geology of Queensland. Geological Survey of Queensland, Brisbane, 1063 pages. <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/reports-news/geology-queensland-book-map>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:IntrusionCentreCluster ;
   skos:definition "A cluster of related plutons [e.g., the Forsayth Batholith (of the Forsayth Supersuite, Forsayth Subprovince, Etheridge Province, northern Queensland)], although the term ‘pluton cluster’ has not been applied per se to the unit, although it ‘comprises ~30 individual plutons or clusters of plutons 2–10 km in diameter’ (Jell, 2013, pp. 61, 80–81)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrpcl" ;
@@ -531,7 +498,6 @@ rur:Ring-dyke
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:altLabel "Ring-dike"@en ;
-  skos:broader rur:Intrusion ;
   skos:definition "A sheet that is arcuate or annular in plan, and usually vertical or inclined steeply outwards (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrrdy" ;
@@ -566,7 +532,6 @@ rur:RingIntrusion
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "An intrusion that is emplaced within, or bounded by, a ring-fracture (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrrin" ;
@@ -578,7 +543,6 @@ rur:Sheet
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "An intrusion sensu lato with broadly parallel margins and one dimension much shorter than the other two (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrsht" ;
@@ -613,7 +577,6 @@ rur:Sill
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "A sheet emplaced along a gently inclined to horizontal fracture; normally broadly concordant in strata (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrsil" ;
@@ -625,7 +588,6 @@ rur:SillCluster
   a skos:Concept ;
   dcterms:references "After: Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212, figure 4. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:IntrusionCentreCluster ;
   skos:definition "A cluster of related sills."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrscl" ;
@@ -679,7 +641,7 @@ rur:Subassemblage
   skos:prefLabel "subassemblage"@en ;
   skos:related geof:TectonometamorphicRockUnit ;
   skos:scopeNote "A rank term newly defined by Gillespie & Leslie (2021) for tectonometamorphic units, with potential for application to such rock types in Queensland and Australia. The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
-  skos:broader <http://sweetontology.net/realmGeol/GeologicFeature> ;
+  skos:broader rur:Assemblage ;
 .
 rur:Subcomplex
   a skos:Concept ;
@@ -723,7 +685,6 @@ rur:Suite
   dcterms:references "Compare: North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Supersuite ;
   skos:definition "A group of two or more related intrusive igneous rock units. Two or more related suites may form a supersuite, and a suite may be subdived into two or more suites (After: Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrsui" ;
@@ -740,6 +701,7 @@ rur:Superassemblage
   skos:prefLabel "superassemblage"@en ;
   skos:related geof:TectonometamorphicRockUnit ;
   skos:scopeNote "A rank term newly defined by Gillespie & Leslie (2021) for tectonometamorphic units, with potential for application to such rock types in Queensland and Australia. The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
+  skos:broader <http://sweetontology.net/realmGeol/GeologicFeature> ;
 .
 rur:Supercomplex
   a skos:Concept ;
@@ -782,7 +744,6 @@ rur:Swarm
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "A group of two or more related intrusive units, such as cone-sheets, diatremes, dykes, laccoliths, necks, pipes, plugs, ring-dykes, sheets, sills and veins, that are spatially associated (After: Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrswm" ;
@@ -794,7 +755,6 @@ rur:Vein
   a skos:Concept ;
   dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
   rdfs:isDefinedBy <https://linked.data.gov.au/def/rock-unit-rank> ;
-  skos:broader rur:Intrusion ;
   skos:definition "An intrusion that is sheet-like, but generally narrower and less regular than a sheet (Gillespie & Leslie, 2021)."@en ;
   skos:inScheme <https://linked.data.gov.au/def/rock-unit-rank> ;
   skos:notation "rrvei" ;


### PR DESCRIPTION
Nick
1. I have flattened the structure further than what you suggested, looking at the logic of your suggestions/recommendations. If this is acceptable, then edits to my definitions will be needed to accord with these changes, but one step at a time.
2. The only hierarchial  relationships left now are associated with: 'member' which has to be part of a 'formation'; 'subsuite' which has to be part a suite; and 'subassemblage' which has to be part of an 'assemblage'.
3. I have transferred the SWEET association with 'Subassemblage' to 'Superassemblage', as the latter has the highest order of rank.
4. beds, bed, flow can stand on their own.
5. intrusioncentrecluster was made up by me, to combine centre and cluster (both equally assigned to Rank 4 in BRUCS). With the flattening, it is no longer required.
6. I've scrapped 'intrusion' as the basic unit of rank of intrusive rock units. It remains in the vocab, but can be considered (inferred) to have a lower order of rank, being assigned to Rank 6 in BRUCS.

Is it possible for you to add me as the author of this vocab, with you being a contributor?

Cheers,
 John